### PR TITLE
Add arrayBuffer and gBytes methods to fetch

### DIFF
--- a/src/std/fetch.js
+++ b/src/std/fetch.js
@@ -51,6 +51,14 @@ export default async function fetch(url, options = {}) {
       return JSON.parse(text);
     },
     async text() {
+      const gBytes = await this.gBytes();
+      return new TextDecoder().decode(gBytes.toArray());
+    },
+    async arrayBuffer() {
+      const gBytes = await this.gBytes();
+      return gBytes.toArray().buffer;
+    },
+    async gBytes() {
       const outputStream = Gio.MemoryOutputStream.new_resizable();
 
       await promiseTask(
@@ -65,8 +73,7 @@ export default async function fetch(url, options = {}) {
       );
 
       const bytes = outputStream.steal_as_bytes();
-
-      return new TextDecoder().decode(bytes.toArray());
+      return bytes;
     },
   };
 }

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -50,6 +50,27 @@ test("get json", async () => {
   server.disconnect();
 });
 
+test("get binary (arrayBuffer, gBytes)", async () => {
+  const value = JSON.stringify({ hello: "world" });
+  const uintValue = new Uint8Array(new TextEncoder().encode(value));
+
+  const server = new Soup.Server();
+  server.add_handler("/bin", (self, message) => {
+    message.get_response_body().append(value);
+    message.set_status(200, null);
+  });
+  server.listen(Gio.InetSocketAddress.new_from_string("127.0.0.1", 1234), null);
+
+  let res;
+  res = await fetch("http://127.0.0.1:1234/bin");
+  assert.equal(new Uint8Array(await res.arrayBuffer()), uintValue);
+
+  res = await fetch("http://127.0.0.1:1234/bin");
+  assert.equal((await res.gBytes()).toArray(), uintValue);
+
+  server.disconnect();
+});
+
 test("POST", async () => {
   const server = new Soup.Server();
   const request_body = JSON.stringify({ hello: "world" });

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -50,7 +50,7 @@ test("get json", async () => {
   server.disconnect();
 });
 
-test("get binary (arrayBuffer, gBytes)", async () => {
+test("get arrayBuffer", async () => {
   const value = JSON.stringify({ hello: "world" });
   const uintValue = new Uint8Array(new TextEncoder().encode(value));
 
@@ -61,11 +61,24 @@ test("get binary (arrayBuffer, gBytes)", async () => {
   });
   server.listen(Gio.InetSocketAddress.new_from_string("127.0.0.1", 1234), null);
 
-  let res;
-  res = await fetch("http://127.0.0.1:1234/bin");
+  const res = await fetch("http://127.0.0.1:1234/bin");
   assert.equal(new Uint8Array(await res.arrayBuffer()), uintValue);
 
-  res = await fetch("http://127.0.0.1:1234/bin");
+  server.disconnect();
+});
+
+test("get gBytes", async () => {
+  const value = JSON.stringify({ hello: "world" });
+  const uintValue = new Uint8Array(new TextEncoder().encode(value));
+
+  const server = new Soup.Server();
+  server.add_handler("/bin", (self, message) => {
+    message.get_response_body().append(value);
+    message.set_status(200, null);
+  });
+  server.listen(Gio.InetSocketAddress.new_from_string("127.0.0.1", 1234), null);
+
+  const res = await fetch("http://127.0.0.1:1234/bin");
   assert.equal((await res.gBytes()).toArray(), uintValue);
 
   server.disconnect();


### PR DESCRIPTION
This PR makes it possible to use `fetch` to get binary data.

`arrayBuffer` is a [standard method](https://developer.mozilla.org/en-US/docs/Web/API/Response/arrayBuffer) of fetch.
`gBytes` is non standard, but it's needed in the gjs world (calling `arrayBuffer` and then converting to `GBytes` would require more copying) . 