### PR TITLE
fix: ensure valid Sec-WebSocket-Protocol

### DIFF
--- a/src/std/WebSocket.js
+++ b/src/std/WebSocket.js
@@ -43,7 +43,7 @@ export default class WebSocket {
         "websocket_connect_finish",
         message,
         "origin",
-        protocols,
+        protocols.length === 0 ? null : protocols,
         null,
         null,
       );


### PR DESCRIPTION
Hi,

The WebSocket RFC requires in [section 4.1 item 10](https://datatracker.ietf.org/doc/html/rfc6455#page-18) for the Sec-WebSocket-Protocol header that

> If present, this value indicates one or more comma-separated 
> subprotocol the client wishes to speak [...]

Strict implementations like the popular Node.js library *ws* [follow that definition to the letter](https://github.com/websockets/ws/issues/1965) and abort the handshake, if the Sec-WebSocket-Protocol  header is set but empty. Ideally, soup should reject an empty list of protocols or handle it gracefully but unfortunately does neither.

Thank you for your time!

Konrad