### PR TITLE
Init download-esm

### DIFF
--- a/download-esm/README.md
+++ b/download-esm/README.md
@@ -1,0 +1,15 @@
+# download-esm
+
+It's a program which can be used to download an npm package and all of its
+dependencies as ESM modules. ESM modules can then be directly imported and used
+in gjs without the need for a bundler.
+
+WARNING: The downloaded files are provided by https://cdn.jsdelivr.net, a popular CDN for npm packages.
+Using this tool means you are trusting that CDN to provide you with the correct files.
+
+This is a rewrite of `https://github.com/simonw/download-esm` using gjs.
+
+## Usage
+```
+Usage: download-esm PACKAGE OUTPUT_DIR
+```

--- a/download-esm/download-esm.js
+++ b/download-esm/download-esm.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S gjs -m
 
 // This is a simple program to download npm packages as esm modules.
-// Running `gjs -m ./src/download-esm.js solid-js ./js` will download
-// `solid-js` and its dependencies, writing them to the `./js` folder.
+// Running `gjs -m ./src/download-esm.js @observablehq/plot ./js` will download
+// `@observablehq/plot` and its dependencies, writing them to the `./js` folder.
 
 import Gio from "gi://Gio"
 import { download } from "./lib.js"

--- a/download-esm/download-esm.js
+++ b/download-esm/download-esm.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env -S gjs -m
+
+// This is a simple program to download npm packages as esm modules.
+// Running `gjs -m ./src/download-esm.js solid-js ./js` will download
+// `solid-js` and its dependencies, writing them to the `./js` folder.
+
+import Gio from "gi://Gio"
+import { download } from "./lib.js"
+
+async function main(argv) {
+    const HELP = `Usage: download-esm <package> <output-path>`
+    const [pkg, output_path] = argv
+    const folder = Gio.File.new_for_path(output_path);
+    if (!folder.query_exists(null)) {
+        folder.make_directory(null);
+    }
+    await download(pkg, folder)
+}
+
+await main(ARGV)

--- a/download-esm/download-esm.test.js
+++ b/download-esm/download-esm.test.js
@@ -1,0 +1,53 @@
+import tst, { assert } from "../tst/tst.js";
+import * as downloadEsm from "./lib.js";
+
+const test = tst("download-esm");
+
+test("extract_original_file", () => {
+    const content = `Random text
+    Original file: /npm/@observablehq/plot@0.6.6/src/index.js
+    `;
+    const expected = "/npm/@observablehq/plot@0.6.6/src/index.js";
+    const actual = downloadEsm.extract_original_file(content);
+    assert.equal(actual, expected);
+});
+
+test("simplify_path_unscoped", () => {
+    const path = "/npm/react@18.2.0/index.js";
+    assert.equal(downloadEsm.simplify_path(path), "react-18-2-0.js");
+});
+
+test("simplify_path_scoped", () => {
+    const path = "/npm/@observablehq/plot@0.6.6/src/index.js";
+    assert.equal(downloadEsm.simplify_path(path), "observablehq-plot-0-6-6.js");
+});
+
+test("simplify_esm", () => {
+    const path = "/npm/isoformat@0.2.1/+esm";
+    assert.equal(downloadEsm.simplify_path(path), "isoformat-0-2-1.js");
+});
+
+test("rewrite_code", () => {
+    const code = `
+        import {f1, f2, f3} from "/npm/isoformat@0.2.1/+esm";
+        import solid from "/npm/solid-js@1.0.1/+esm";
+        //# sourceMappingURL=/sm/01413fe1f7a8c2da69e83bcc6c3f16a63658e3f27f5a8ffeda7da895d71e4aa2.map
+        const x = 1;
+    `;
+    const expected_code = `
+        import {f1, f2, f3} from "./isoformat-0-2-1.js";
+        import solid from "./solid-js-1-0-1.js";
+        
+        const x = 1;
+    `
+    const [rewritten_code, captured_paths] = downloadEsm.rewrite_code(code);
+    const expected_captured_paths = {
+        "/npm/isoformat@0.2.1/+esm": "isoformat-0-2-1.js",
+        "/npm/solid-js@1.0.1/+esm": "solid-js-1-0-1.js"
+    };
+    assert.equal(rewritten_code, expected_code);
+    assert.equal(captured_paths, expected_captured_paths);
+});
+
+
+export default test;

--- a/download-esm/lib.js
+++ b/download-esm/lib.js
@@ -1,0 +1,99 @@
+
+import Gio from "gi://Gio"
+import fetch from "../src/std/fetch.js"
+
+function makeUrl(pkg) {
+    return `https://cdn.jsdelivr.net/npm/${pkg}/+esm`
+}
+function makeUrlFromCDNPath(path) {
+    return `https://cdn.jsdelivr.net${path}`
+}
+
+export async function download(pkg, folder, { downloaded, simplified_path } = {}) {
+    if (!downloaded) {
+        downloaded = new Set();
+    }
+
+    let url;
+    if (pkg.indexOf("https://") == 0) {
+        url = pkg;
+    } else {
+        url = makeUrl(pkg)
+    }
+
+    if (downloaded.has(url)) {
+        return;
+    }
+
+    const response = await fetch(url)
+    const { ok, status, statusText } = response
+    if (!ok) {
+        throw new Error(`Failed to download ${pkg}: ${status} ${statusText}`)
+    }
+
+    downloaded.add(url);
+
+    const text = await response.text()
+
+    if (!simplified_path) {
+        const original_file = extract_original_file(text);
+        simplified_path = simplify_path(original_file);
+    }
+    print("Downloading", simplified_path);
+    const [rewritten_code, captured_paths] = rewrite_code(text);
+
+    const file = folder.get_child(simplified_path);
+    file.replace_contents(rewritten_code, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null)
+
+    await Promise.all(Object.keys(captured_paths).map(async (path) => {
+        await download(makeUrlFromCDNPath(path), folder, { downloaded, simplified_path: captured_paths[path] })
+    }))
+}
+
+export function extract_original_file(content) {
+    // Looks for Original file: /npm/@observablehq/plot@0.6.6/src/index.js
+    const pattern = /Original file: (\/npm\/[^\s]+)/;
+    const match = content.match(pattern);
+
+    if (match) {
+        return match[1];
+    } else {
+        throw new Error("Could not find original file");
+    }
+}
+
+export function simplify_path(path) {
+    path = path.split("/npm/")[1];
+
+    const is_scoped_pkg = path.indexOf("@") == 0;
+    if (is_scoped_pkg) {
+        path = path.replace("@", "");
+    }
+
+    let [package_name, version] = path.split("@");
+    version = version.split("/")[0];
+    version = version.replace(/\./g, "-");
+    const simplified_name = `${package_name}-${version}.js`;
+    return simplified_name.replace("/", "-");
+}
+
+export function rewrite_code(code) {
+    const pattern = /(?<keyword>import|export)\s*(?<imports>\{?[^}]+?\}?)\s*from\s*"(?<path>\/npm\/[^"]+)"/g;
+    const captured_paths = {};
+
+    function replace_import(_match, keyword, imports, path) {
+        const simplified_path = simplify_path(path);
+        captured_paths[path] = simplified_path;
+        return `${keyword} ${imports} from "./${simplified_path}"`;
+    }
+
+    let rewritten_code = code.replaceAll(pattern, replace_import);
+    rewritten_code = remove_source_mapping_comments(rewritten_code);
+    return [rewritten_code, captured_paths];
+}
+
+export function remove_source_mapping_comments(code) {
+    const pattern = /\/\/#\s*sourceMappingURL=.*?\.map/g;
+    const cleaned_code = code.replace(pattern, "");
+    return cleaned_code;
+}


### PR DESCRIPTION
I've found the tool `https://github.com/simonw/download-esm` pretty useful to quickly download and import npm packages as esm modules. 
By downloading the files directly as esm modules, we can import them without using a bundler.

So, I've just rewritten that tool above in js.
It's even faster, because I'm fetching the dependencies in parallel.

Why am I sending a pull request and not opening a personal repo?
Because this is a very little program, and it depends just on `troll`. Also, it fits with the other tooling available in this repo.