### PR TITLE
theme-selector: Subclass AdwBin

### DIFF
--- a/src/widgets/ThemeSelector.blp
+++ b/src/widgets/ThemeSelector.blp
@@ -1,6 +1,7 @@
 using Gtk 4.0;
+using Adw 1;
 
-template $ThemeSelector : Widget {
+template $ThemeSelector : Adw.Bin {
   hexpand: true;
 
   Box box {

--- a/src/widgets/ThemeSelector.js
+++ b/src/widgets/ThemeSelector.js
@@ -9,9 +9,8 @@ import Style from "./ThemeSelector.css";
 const style_manager = Adw.StyleManager.get_default();
 let provider;
 
-class ThemeSelector extends Gtk.Widget {
+class ThemeSelector extends Adw.Bin {
   constructor(params = {}) {
-    ThemeSelector.set_layout_manager_type(Gtk.BinLayout);
     super(params);
 
     style_manager.connect(


### PR DESCRIPTION
One has to manually remove the child of a Widget subclass, Bin takes care of this for us.