### PR TITLE
Byte array for non-text data in WebSocket message event

### DIFF
--- a/src/std/WebSocket.js
+++ b/src/std/WebSocket.js
@@ -74,7 +74,7 @@ export default class WebSocket {
         const data = text_decoder.decode(message.toArray());
         this._onmessage({ data });
       } else {
-        this._onmessage({ data: message });
+        this._onmessage({ data: message.toArray() });
       }
     });
   }


### PR DESCRIPTION
This fixes an issue I had with https://jsr.io/@ymjacky/mqtt5 where it was expecting a Uint8Array.